### PR TITLE
logging levels and colors regardless of grunt.verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,14 @@ Find a complete list of the options available at https://github.com/simianhacker
 Type: `Boolean`
 Default value: `false`
 
-The only additional option that you can specify in grunt-esvm is `quiet`. This will prevent elasticsearch from logging to the console, and will simply start it up in the backgroun.
+An additional option that you can specify in `grunt-esvm` is `quiet`. This will prevent `elasticsearch` from logging to the console at all.
+
+#### options.level
+Type: `String`
+Default value: `'info'`
+Values: One of `['debug', 'info', 'warning', 'error', 'fatal']`
+
+An additional option that you can specify in `grunt-esvm` is `level`. This will determine the logging level from `elasticsearch` that will be output to the console.
 
 ### Usage Examples
 

--- a/lib/logClusterLogs.js
+++ b/lib/logClusterLogs.js
@@ -9,44 +9,69 @@ var clc = require('cli-color');
 var CliTable = require('cli-table');
 var _ = require('lodash');
 
-// mapping for log levels to grunt log methods
+// mappings for log levels to grunt log methods
 var writes = {
-  INFO: grunt.verbose.writeln,
-  DEBUG: grunt.log.debug,
-  WARN: grunt.log.writeln,
   default: grunt.log.writeln,
-  ERROR: grunt.log.error,
-  FATAL: grunt.fail.warn
+  3: grunt.log.error,
+  4: grunt.fail.warn
 };
 
 var colors = {
-  INFO: clc.green,
-  DEBUG: clc.cyan,
-  default: function (txt) { return clc.reset + txt; },
-  WARN: clc.yellow,
-  FATAL: clc.magentaBright,
-  ERROR: clc.white.bgRed
+  default: function (text) { return clc.reset + text; },
+  0: clc.cyan,
+  1: clc.green,
+  2: clc.yellow,
+  3: clc.white.bgRed,
+  4: clc.magentaBright
 };
 
-function logClusterLogs(cluster) {
-  cluster.on('log', function(log) {
-    // ignore progress events for now
-    if (log.type === 'progress') return;
+function logScore (level) {
+  var logScores = {
+    debug: 0,
+    default: 1,
+    info: 1,
+    warn: 2,
+    warning: 2,
+    error: 3,
+    fatal: 4
+  };
+  var logLevel = level && level.toLowerCase() || 'default';
+  return logScores[logLevel];
+}
 
-    if (typeof log === 'string') {
-      write(log);
+function logClusterLogs(cluster, configuredLevel, quiet) {
+  if (quiet) {
+    return noop;
+  }
+  cluster.on('log', onClusterLog);
+  return flush;
+  function onClusterLog(log) {
+    if (log.type === 'progress') { // ignore progress events for now
       return;
     }
-
-    var write = writes[log.level] || writes.default;
-    var color = colors[log.level] || colors.default;
+    if (typeof log === 'string') {
+      flush('default', log);
+      return;
+    }
+    var logLevel = logScore(log.level);
+    if (logLevel < logScore(configuredLevel)) {
+      return;
+    }
     var msg = [
-      log.level || '',
-      log.node || '',
+      log.node || 'master',
       log.type || '',
       log.message || ''
     ];
-
-    write(msg.join(' - '));
-  });
+    flush(log.level, msg.join(' - '));
+  }
+  function flush(level, message) {
+    var logLevel = logScore(level);
+    var writer = writes[logLevel] || writes.default;
+    var color = colors[logLevel] || colors.default;
+    var prefix = clc.white.bgBlue('[esvm]');
+    var levelText = color(level ? ' ' + level.toUpperCase() : '');
+    writer(prefix + levelText + ' - ' + message);
+  }
 }
+
+function noop() {}

--- a/lib/logClusterLogs.js
+++ b/lib/logClusterLogs.js
@@ -4,10 +4,10 @@
  */
 module.exports = logClusterLogs;
 
+var _ = require('lodash');
 var grunt = require('grunt');
 var clc = require('cli-color');
-var CliTable = require('cli-table');
-var _ = require('lodash');
+var prefix = clc.white.bgBlue('[esvm]');
 
 // mappings for log levels to grunt log methods
 var writes = {
@@ -44,6 +44,7 @@ function logClusterLogs(cluster, configuredLevel, quiet) {
     return noop;
   }
   cluster.on('log', onClusterLog);
+  flush.pad = pad;
   return flush;
   function onClusterLog(log) {
     if (log.type === 'progress') { // ignore progress events for now
@@ -60,6 +61,9 @@ function logClusterLogs(cluster, configuredLevel, quiet) {
     ];
     flush(log.level, msg.join(' - '));
   }
+  function getLevelText (level) {
+    return level ? ' ' + level.toUpperCase() : '';
+  }
   function flush(level, message) {
     var logLevel = logScore(level);
     if (logLevel < logScore(configuredLevel)) {
@@ -67,9 +71,13 @@ function logClusterLogs(cluster, configuredLevel, quiet) {
     }
     var writer = writes[logLevel] || writes.default;
     var color = colors[logLevel] || colors.default;
-    var prefix = clc.white.bgBlue('[esvm]');
-    var levelText = color(level ? ' ' + level.toUpperCase() : '');
+    var levelText = color(getLevelText(level));
     writer(prefix + levelText + ' - ' + message);
+  }
+  function pad (level, message) {
+    var levelText = _.repeat(' ', getLevelText(level).length + 3);
+    var padding = prefix + levelText;
+    return padding + message.split('\n').join('\n' + padding);
   }
 }
 

--- a/lib/logClusterLogs.js
+++ b/lib/logClusterLogs.js
@@ -53,10 +53,6 @@ function logClusterLogs(cluster, configuredLevel, quiet) {
       flush('default', log);
       return;
     }
-    var logLevel = logScore(log.level);
-    if (logLevel < logScore(configuredLevel)) {
-      return;
-    }
     var msg = [
       log.node || 'master',
       log.type || '',
@@ -66,6 +62,9 @@ function logClusterLogs(cluster, configuredLevel, quiet) {
   }
   function flush(level, message) {
     var logLevel = logScore(level);
+    if (logLevel < logScore(configuredLevel)) {
+      return;
+    }
     var writer = writes[logLevel] || writes.default;
     var color = colors[logLevel] || colors.default;
     var prefix = clc.white.bgBlue('[esvm]');

--- a/tasks/esvm.js
+++ b/tasks/esvm.js
@@ -96,9 +96,11 @@ module.exports = function (grunt) {
 
       return get('http://localhost:' + node.port, { json: 'force' })
       .spread(function (resp, payload) {
-        if (resp.statusCode > 200) return node;
+        if (resp.statusCode > 200) {
+          return node;
+        }
 
-        log('debug', 'grunt - ' + payload);
+        log('debug', 'grunt - Payload at http://localhost:' + node.port + '\n' + JSON.stringify(payload, null, 2));
         var sha = _.get(payload, 'version.build_hash', '').slice(0, 7);
         if (String(sha).match(/\$\{.+\}/)) {
           node.branchInfo = '- no build info -';
@@ -111,19 +113,15 @@ module.exports = function (grunt) {
       });
     })
     .then(function (nodes) {
-      log('info', 'grunt - Started ' + nodes.length + ' Elasticsearch nodes.');
-
       var showBranch = _.some(nodes, 'branch');
       var showVersion = _.some(nodes, 'version');
 
-      var t = [
-        [
-          'port',
-          showBranch ? 'branch' : null,
-          showVersion ? 'version' : null,
-          'node name'
-        ]
-      ].concat(nodes.map(function (node) {
+      var t = [[
+        'port',
+        showBranch ? 'branch' : null,
+        showVersion ? 'version' : null,
+        'node name'
+      ]].concat(nodes.map(function (node) {
         return [
           node.port || '?',
           showBranch ? node.branchInfo || '?': null,
@@ -143,7 +141,7 @@ module.exports = function (grunt) {
         table.push(r);
       });
 
-      log('info', 'grunt - ' + table.toString());
+      log('info', 'Started ' + nodes.length + ' Elasticsearch nodes.\n' + table.toString());
     });
 
     if (keepalive === 'keepalive') {

--- a/tasks/esvm.js
+++ b/tasks/esvm.js
@@ -141,7 +141,7 @@ module.exports = function (grunt) {
         table.push(r);
       });
 
-      log('info', 'Started ' + nodes.length + ' Elasticsearch nodes.\n' + table.toString());
+      log('info', 'Started ' + nodes.length + ' Elasticsearch nodes.\n' + log.pad('info', table.toString()));
     });
 
     if (keepalive === 'keepalive') {


### PR DESCRIPTION
Fixes #3 

logging level in `grunt-esvm` should be configurable to our liking and not dependant on Grunt's own messaging logging levels. This PR adds a `level` option and prefixes every message from `grunt-esvm` with a label so that it's clear where messages are coming from.

Before

<img width="518" alt="screen shot 2016-03-14 at 15 39 01" src="https://cloud.githubusercontent.com/assets/934293/13755855/ea4824d6-e9fb-11e5-9c28-d0ca24ed379f.png">

After

<img width="626" alt="screen shot 2016-03-14 at 15 38 25" src="https://cloud.githubusercontent.com/assets/934293/13755853/e80e32f0-e9fb-11e5-972e-301429a60e5e.png">
