### PR TITLE
Resolve #3 Write all elasticsearch logs by default

### DIFF
--- a/lib/logClusterLogs.js
+++ b/lib/logClusterLogs.js
@@ -9,16 +9,6 @@ var clc = require('cli-color');
 var CliTable = require('cli-table');
 var _ = require('lodash');
 
-// mapping for log levels to grunt log methods
-var writes = {
-  INFO: grunt.verbose.writeln,
-  DEBUG: grunt.log.debug,
-  WARN: grunt.log.writeln,
-  default: grunt.log.writeln,
-  ERROR: grunt.log.error,
-  FATAL: grunt.fail.warn
-};
-
 var colors = {
   INFO: clc.green,
   DEBUG: clc.cyan,
@@ -38,15 +28,14 @@ function logClusterLogs(cluster) {
       return;
     }
 
-    var write = writes[log.level] || writes.default;
     var color = colors[log.level] || colors.default;
     var msg = [
-      log.level || '',
+      color(log.level) || '',
       log.node || '',
       log.type || '',
       log.message || ''
     ];
 
-    write(msg.join(' - '));
+    grunt.log.writeln(msg.join(' - '));
   });
 }


### PR DESCRIPTION
Resolve #3 

Changes grunt-esvm to log all Elasticsearch logs be default. This allows grunt task logs and Elasticsearch logs to be dialed up or down in verbosity independently of each other.
