### PR TITLE
Update dependencies for Node 6 compatability

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "grunt": ">=0.4.0",
-    "load-grunt-config": "~0.14.0"
+    "load-grunt-config": "~0.19.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
+    "grunt": ">=0.4.0",
     "load-grunt-config": "~0.14.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.5"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
Updates transitive dependency of graceful-fs to be ~4.0.0
